### PR TITLE
change username match to be exact

### DIFF
--- a/src/main/java/net/wimpi/crowd/ldap/CrowdPartition.java
+++ b/src/main/java/net/wimpi/crowd/ldap/CrowdPartition.java
@@ -495,7 +495,7 @@ public class CrowdPartition implements Partition {
               userName = NullRestrictionImpl.INSTANCE;
               
           } else {
-              userName = new TermRestriction<String>(UserTermKeys.USERNAME, MatchMode.CONTAINS, uid);
+              userName = new TermRestriction<String>(UserTermKeys.USERNAME, MatchMode.EXACTLY_MATCHES, uid);
           }
           List<String> list = m_CrowdClient.searchUserNames(userName, 0, Integer.MAX_VALUE);
           for (String gn : list) {


### PR DESCRIPTION
MatchMode.CONTAINS causes username clashes and fails authentication for users that have a partial username match. MatchMode.EXACTLY_MATCHES fixes, tested and confirmed